### PR TITLE
Use full path to find documents

### DIFF
--- a/src/util/operation.ts
+++ b/src/util/operation.ts
@@ -5,7 +5,7 @@ const findIndexOfDocument = (
   items: firestore.DocumentData[]
 ): number =>
   items.findIndex((item) => {
-    return item.id === doc.id;
+    return item.ref.path === doc.ref.path;
   });
 
 export const updateItem = (


### PR DESCRIPTION
I have a use case with a firestore structure something like:

```
/original/{docID}
/user/{userID}/work/{docID}
```

So users create their own version of the original document (I couldn't find any information of if this is poor design due to the same ids even though the full paths are different).

For example:

/original/**foo**
/user/bar/work/**foo**
/user/baz/work/**foo**

My query uses a collectionGroup on `work` but I only get one result because duplicate documents are found by their `id`.
To solve this I think the package should switch to using the full document path to find documents.